### PR TITLE
Add modern CV layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,174 +3,165 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lic. Ana López - Psicóloga</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            color: #333;
-            background-color: #fdfdfd;
-        }
-        header {
-            background-color: #e8e6f7;
-            padding: 20px;
-            text-align: center;
-        }
-        header h1 {
-            margin: 0;
-            font-size: 2em;
-            color: #4a4a8a;
-        }
-        header h2 {
-            margin: 5px 0 0;
-            font-weight: normal;
-            font-size: 1.2em;
-            color: #7c7c9a;
-        }
-        nav ul {
-            list-style: none;
-            padding: 0;
-            margin: 20px 0 0;
-            display: flex;
-            justify-content: center;
-            gap: 20px;
-        }
-        nav a {
-            text-decoration: none;
-            color: #4a4a8a;
-            font-weight: bold;
-        }
-        .hero {
-            background-color: #f0f8f6;
-            padding: 60px 20px;
-            text-align: center;
-        }
-        .hero h3 {
-            margin-top: 0;
-            color: #4a4a8a;
-            font-size: 1.5em;
-        }
-        .hero p {
-            max-width: 600px;
-            margin: 20px auto 0;
-            font-size: 1.1em;
-        }
-        section {
-            padding: 40px 20px;
-            max-width: 800px;
-            margin: auto;
-        }
-        .about img {
-            max-width: 100%;
-            height: auto;
-            border-radius: 8px;
-            margin-top: 20px;
-        }
-        .services ul {
-            list-style: none;
-            padding: 0;
-        }
-        .services li {
-            margin-bottom: 10px;
-        }
-        .cta {
-            background-color: #e8e6f7;
-            text-align: center;
-            padding: 40px 20px;
-        }
-        .cta a {
-            background-color: #4a4a8a;
-            color: white;
-            padding: 10px 20px;
-            text-decoration: none;
-            border-radius: 4px;
-        }
-        form {
-            display: grid;
-            gap: 10px;
-        }
-        input, textarea {
-            padding: 10px;
-            font-size: 1em;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-        }
-        button {
-            padding: 10px;
-            font-size: 1em;
-            background-color: #4a4a8a;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        footer {
-            background-color: #f0f8f6;
-            text-align: center;
-            padding: 20px;
-            font-size: 0.9em;
-        }
-        @media (min-width: 600px) {
-            nav ul {
-                gap: 40px;
-            }
-        }
-    </style>
+    <title>Kristel Manríquez - CV</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <header>
-        <h1>Lic. Ana López</h1>
-        <h2>Psicóloga</h2>
-        <nav>
+    <div class="layout">
+        <nav class="sidebar">
             <ul>
-                <li><a href="#">Inicio</a></li>
-                <li><a href="#sobre-mi">Sobre mí</a></li>
-                <li><a href="#servicios">Servicios</a></li>
-                <li><a href="#contacto">Contacto</a></li>
+                <li data-section="about" class="active">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" stroke="currentColor" stroke-width="2"/>
+                        <path d="M4 22C4 17.5817 7.58172 14 12 14C16.4183 14 20 17.5817 20 22" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                    <span>Sobre mí</span>
+                </li>
+                <li data-section="experience">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M3 7H21V21H3V7Z" stroke="currentColor" stroke-width="2"/>
+                        <path d="M16 3H8V7H16V3Z" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                    <span>Experiencia &amp; Formación</span>
+                </li>
+                <li data-section="works">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M3 3H21V21H3V3Z" stroke="currentColor" stroke-width="2"/>
+                        <path d="M3 9H21" stroke="currentColor" stroke-width="2"/>
+                        <path d="M9 21V9" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                    <span>Trabajos</span>
+                </li>
+                <li data-section="contact">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M21 10L13 3V8H3V12H13V17L21 10Z" stroke="currentColor" stroke-width="2"/>
+                    </svg>
+                    <span>Contacto</span>
+                </li>
             </ul>
         </nav>
-    </header>
-
-    <div class="hero">
-        <h3>Acompañándote en tu proceso de bienestar emocional</h3>
-        <p>Trabajo desde un enfoque integrador, combinando técnicas de la psicología humanista y la terapia cognitivo conductual.</p>
+        <aside class="profile">
+            <img src="https://via.placeholder.com/150" alt="Kristel Manríquez" class="profile-photo">
+            <h1>Kristel Manríquez</h1>
+            <div class="languages">
+                <img src="https://flagcdn.com/w20/es.png" alt="Español">
+                <img src="https://flagcdn.com/w20/gb.png" alt="Inglés">
+            </div>
+            <div class="buttons">
+                <a href="#" class="btn">&#x2B07; Descargar CV</a>
+                <a href="#contact" class="btn">Hablemos</a>
+            </div>
+        </aside>
+        <main class="sections">
+            <section id="about" class="section active">
+                <h2>Sobre mí</h2>
+                <p>Profesional con amplia experiencia en desarrollo web. Apasionada por crear interfaces intuitivas y atractivas.</p>
+                <div class="skills">
+                    <div class="skill" data-percent="80">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>HTML/CSS</span>
+                    </div>
+                    <div class="skill" data-percent="80">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>JavaScript</span>
+                    </div>
+                    <div class="skill" data-percent="85">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>SQL-NoSQL</span>
+                    </div>
+                    <div class="skill" data-percent="70">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>Bootstrap/Vuetify/MUI</span>
+                    </div>
+                    <div class="skill" data-percent="80">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>Figma</span>
+                    </div>
+                    <div class="skill" data-percent="70">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>Vue/React</span>
+                    </div>
+                    <div class="skill" data-percent="50">
+                        <svg viewBox="0 0 36 36">
+                            <path class="bg" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                            <path class="bar" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831"/>
+                        </svg>
+                        <span>Java/Python/PHP</span>
+                    </div>
+                </div>
+            </section>
+            <section id="experience" class="section">
+                <h2>Experiencia &amp; Formación</h2>
+                <ul>
+                    <li>Desarrolladora Web - Empresa X (2019-2023)</li>
+                    <li>Ingeniería en Informática - Universidad Y</li>
+                </ul>
+            </section>
+            <section id="works" class="section">
+                <h2>Trabajos</h2>
+                <p>Lista de proyectos destacados y links.</p>
+            </section>
+            <section id="contact" class="section">
+                <h2>Contacto</h2>
+                <form>
+                    <input type="text" placeholder="Nombre" required>
+                    <input type="email" placeholder="Email" required>
+                    <textarea placeholder="Mensaje" rows="5" required></textarea>
+                    <button type="submit">Enviar</button>
+                </form>
+            </section>
+        </main>
     </div>
-
-    <section id="sobre-mi" class="about">
-        <h3>Sobre mí</h3>
-        <p>Soy Licenciada en Psicología con más de diez años de experiencia en el acompañamiento de adolescentes y adultos. Me especializo en procesos de crecimiento personal y manejo de la ansiedad.</p>
-        <img src="https://via.placeholder.com/400x250" alt="Foto de la psicóloga">
-    </section>
-
-    <section id="servicios" class="services">
-        <h3>Servicios</h3>
-        <ul>
-            <li>Psicoterapia individual presencial y online</li>
-            <li>Orientación vocacional</li>
-            <li>Talleres de manejo de estrés</li>
-        </ul>
-    </section>
-
-    <section class="cta">
-        <h3>¿Listo para comenzar tu proceso?</h3>
-        <a href="#contacto">Reservar turno</a>
-    </section>
-
-    <section id="contacto">
-        <h3>Contacto</h3>
-        <form>
-            <input type="text" name="nombre" placeholder="Nombre" required>
-            <input type="email" name="email" placeholder="Email" required>
-            <textarea name="mensaje" rows="5" placeholder="Mensaje" required></textarea>
-            <button type="submit">Enviar</button>
-        </form>
-    </section>
-
-    <footer>
-        <p>WhatsApp: +54 9 11 1234-5678 | Dirección: Calle Falsa 123, Ciudad</p>
-        <p>Sígueme en <a href="#">Instagram</a> y <a href="#">Facebook</a></p>
-        <p>La confidencialidad de tus datos está garantizada.</p>
-    </footer>
+<script>
+// Navegación entre secciones
+const sidebarItems = document.querySelectorAll('.sidebar li');
+const sections = document.querySelectorAll('.section');
+sidebarItems.forEach(item => {
+    item.addEventListener('click', () => {
+        sidebarItems.forEach(i => i.classList.remove('active'));
+        item.classList.add('active');
+        const target = item.getAttribute('data-section');
+        sections.forEach(sec => {
+            if(sec.id === target) {
+                sec.classList.add('active');
+            } else {
+                sec.classList.remove('active');
+            }
+        });
+    });
+});
+// Círculos de progreso
+const skills = document.querySelectorAll('.skill');
+skills.forEach(skill => {
+    const percent = skill.getAttribute('data-percent');
+    const circle = skill.querySelector('.bar');
+    const radius = 15.9155;
+    const circumference = 2 * Math.PI * radius;
+    circle.style.strokeDasharray = `${circumference}`;
+    circle.style.strokeDashoffset = `${circumference}`;
+    setTimeout(() => {
+        const offset = circumference - (percent / 100) * circumference;
+        circle.style.strokeDashoffset = offset;
+    }, 300);
+});
+</script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,112 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: linear-gradient(135deg, #c8f3ff, #a0e0ff);
+    color: #333;
+}
+.layout {
+    display: flex;
+    min-height: 100vh;
+}
+.sidebar {
+    width: 80px;
+    background-color: #ffffffaa;
+    backdrop-filter: blur(6px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 20px;
+}
+.sidebar ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.sidebar li {
+    cursor: pointer;
+    margin: 20px 0;
+    text-align: center;
+    color: #008080;
+    transition: color 0.3s;
+}
+.sidebar li.active,
+.sidebar li:hover {
+    color: #006666;
+}
+.sidebar svg {
+    display: block;
+    margin: 0 auto 5px;
+}
+.profile {
+    width: 220px;
+    background-color: #ffffffcc;
+    padding: 20px;
+    text-align: center;
+}
+.profile-photo {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.languages img {
+    width: 24px;
+    margin: 5px;
+}
+.buttons {
+    margin-top: 15px;
+}
+.btn {
+    display: inline-block;
+    margin: 5px;
+    padding: 8px 12px;
+    background-color: #00a0a0;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+}
+.sections {
+    flex: 1;
+    padding: 40px;
+}
+.section {
+    display: none;
+}
+.section.active {
+    display: block;
+}
+.skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 20px;
+}
+.skill {
+    width: 100px;
+    text-align: center;
+}
+.skill svg {
+    width: 80px;
+    height: 80px;
+    transform: rotate(-90deg);
+}
+.skill .bg {
+    fill: none;
+    stroke: #eee;
+    stroke-width: 3;
+}
+.skill .bar {
+    fill: none;
+    stroke: #00a0a0;
+    stroke-width: 3;
+    stroke-linecap: round;
+    transition: stroke-dashoffset 1s ease-out;
+}
+@media (max-width: 768px) {
+    .profile {
+        width: 160px;
+    }
+    .sections {
+        padding: 20px;
+    }
+}


### PR DESCRIPTION
## Summary
- build a single page CV style layout for Kristel Manríquez
- include sidebar navigation with icons
- add profile panel with languages and action buttons
- show/hide content sections with JS
- style with new external CSS file

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68840aa69988833182f8b0a368ea9029